### PR TITLE
Serve badge data dynamically

### DIFF
--- a/api-static/projects/cmems81vz0075jp04mfqa8oho/badge-data.json
+++ b/api-static/projects/cmems81vz0075jp04mfqa8oho/badge-data.json
@@ -1,1 +1,0 @@
-{ "showBadge": false }

--- a/api/projects/cmems81vz0075jp04mfqa8oho/badge-data
+++ b/api/projects/cmems81vz0075jp04mfqa8oho/badge-data
@@ -1,1 +1,0 @@
-{"showBadge": false}

--- a/api/projects/cmems81vz0075jp04mfqa8oho/badge-data.json
+++ b/api/projects/cmems81vz0075jp04mfqa8oho/badge-data.json
@@ -1,0 +1,1 @@
+{"showBadge": false}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "rewrites": [
     { "source": "/placeholder.svg", "destination": "/assets/placeholder.svg" },
-    { "source": "/api/projects/:project/badge-data", "destination": "/api-static/projects/:project/badge-data.json" }
+    { "source": "/api/projects/:project/badge-data", "destination": "/api/projects/:project/badge-data.json" }
   ]
 }


### PR DESCRIPTION
## Summary
- rename badge data to `badge-data.json`
- drop static badge data copy and reference dynamic file in `vercel.json`

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc35aba248329a0c1706fd1d1927c